### PR TITLE
Allow overriding default NATS configuration options

### DIFF
--- a/lib/cf_message_bus/message_bus.rb
+++ b/lib/cf_message_bus/message_bus.rb
@@ -9,8 +9,7 @@ module CfMessageBus
     def initialize(config)
       @logger = config[:logger]
 
-      @internal_bus = MessageBusFactory.message_bus(
-        config[:servers] || config[:uris] || config[:uri])
+      @internal_bus = MessageBusFactory.message_bus(config)
 
       @subscriptions = {}
     end

--- a/lib/cf_message_bus/message_bus_factory.rb
+++ b/lib/cf_message_bus/message_bus_factory.rb
@@ -2,11 +2,11 @@ require 'nats/client'
 
 module CfMessageBus
   class MessageBusFactory
-    def self.message_bus(uri)
+    def self.message_bus(config)
       ::NATS.connect(
-        uri: uri,
-        max_reconnect_attempts: -1,
-        dont_randomize_servers: false,
+        uri: config[:servers] || config[:uris] || config[:uri],
+        max_reconnect_attempts: config[:max_reconnect_attempts] || -1,
+        dont_randomize_servers: config[:dont_randomize_servers] || false,
       )
     end
   end

--- a/lib/cf_message_bus/version.rb
+++ b/lib/cf_message_bus/version.rb
@@ -1,3 +1,3 @@
 module CfMessageBus
-  VERSION = "0.3.5"
+  VERSION = "0.3.6"
 end

--- a/spec/message_bus_factory_spec.rb
+++ b/spec/message_bus_factory_spec.rb
@@ -3,8 +3,9 @@ require "cf_message_bus/message_bus_factory"
 module CfMessageBus
   describe MessageBusFactory do
     let(:uri) { "nats://localhost:4222" }
+    let(:config) { { servers: uri } }
     let(:client) { double(:client) }
-    subject(:get_bus) { MessageBusFactory.message_bus(uri) }
+    subject(:get_bus) { MessageBusFactory.message_bus(config) }
     before do
       ::NATS.stub(:connect).and_return(client)
     end
@@ -24,6 +25,44 @@ module CfMessageBus
     it 'configures to not shuffle servers (workaround for nats lib bug)' do
       ::NATS.should_receive(:connect).with(hash_including(dont_randomize_servers: false))
       get_bus
+    end
+
+    describe 'config' do
+      context 'has :uris' do
+        let(:config) { { uris: uri } }
+
+        it 'should connect to the uri' do
+          ::NATS.should_receive(:connect).with(hash_including(uri: uri))
+          get_bus
+        end
+      end
+
+      context 'has :uri' do
+        let(:config) { { uri: uri } }
+
+        it 'should connect to the uri' do
+          ::NATS.should_receive(:connect).with(hash_including(uri: uri))
+          get_bus
+        end
+      end
+
+      context 'has :max_reconnect_attempts' do
+        let(:config) { { servers: uri, max_reconnect_attempts: 10 } }
+
+        it 'should setup max reconnect attempts' do
+          ::NATS.should_receive(:connect).with(hash_including(max_reconnect_attempts: 10))
+          get_bus
+        end
+      end
+
+      context 'has :dont_randomize_servers' do
+        let(:config) { { servers: uri, dont_randomize_servers: true } }
+
+        it 'should setup max reconnect attempts' do
+          ::NATS.should_receive(:connect).with(hash_including(dont_randomize_servers: true))
+          get_bus
+        end
+      end
     end
   end
 end

--- a/spec/support/message_bus_behaviors.rb
+++ b/spec/support/message_bus_behaviors.rb
@@ -8,7 +8,7 @@ shared_examples :a_message_bus do
     subject(:message_bus) { described_class.new(config) }
 
     before do
-      CfMessageBus::MessageBusFactory.stub(:message_bus).with(bus_uri).and_return(CfMessageBus::MockNATS.new)
+      CfMessageBus::MessageBusFactory.stub(:message_bus).with(config).and_return(CfMessageBus::MockNATS.new)
     end
 
     it 'should be able to subscribe' do


### PR DESCRIPTION
This PR allows the invoker to override the default NATS configuration options. It also bumps the version to `0.3.6`.

This will help us to prevent the issue documented at https://github.com/cloudfoundry/cloud_controller_ng/issues/726.